### PR TITLE
Create .gitignore for buch/

### DIFF
--- a/buch/.gitignore
+++ b/buch/.gitignore
@@ -1,0 +1,12 @@
+buch*.aux
+buch*.bbl
+buch*.bib
+buch*.blg
+buch*.idx
+buch*.ilg
+buch*.ind
+buch*.log
+buch*.out
+buch*.pdf
+buch*.run.xml
+buch*.toc


### PR DESCRIPTION
It is a bit annoying to get that huge list of untracked aux files every time `$ git status` runs